### PR TITLE
Do not check on a specific schema when the schemaName is null or empty

### DIFF
--- a/Hangfire.Oracle/OracleObjectsInstaller.cs
+++ b/Hangfire.Oracle/OracleObjectsInstaller.cs
@@ -35,12 +35,24 @@ namespace Hangfire.Oracle.Core
 
         private static bool TablesExists(IDbConnection connection, string schemaName)
         {
-            return connection.ExecuteScalar<string>($@"
-   SELECT TABLE_NAME
-     FROM all_tables
-    WHERE OWNER = '{schemaName}' AND TABLE_NAME LIKE 'HF_%'
- ORDER BY TABLE_NAME
-") != null;
+            string tableExistsQuery;
+
+            if (!string.IsNullOrEmpty(schemaName))
+            {
+                tableExistsQuery = $@"SELECT TABLE_NAME
+FROM all_tables
+WHERE OWNER = '{schemaName}' AND TABLE_NAME LIKE 'HF_%'
+ORDER BY TABLE_NAME";
+            }
+            else
+            {
+                tableExistsQuery = @"SELECT TABLE_NAME
+FROM all_tables
+WHERE TABLE_NAME LIKE 'HF_%'
+ORDER BY TABLE_NAME";
+            }
+
+            return connection.ExecuteScalar<string>(tableExistsQuery) != null;
         }
 
         private static string GetStringResource(string resourceName)


### PR DESCRIPTION
When using this library I had an issue when no SchemaName was provided. 

The first time I started the application the tables were created on the default schema (schema that was set in the connectionstring).
But when I started the application again the TableExists check returned false because it was looking for the table in the schema ''.

This pull request fixes this.